### PR TITLE
fix(ballistics): re-fit aero coefficients against TrackMan reference capture

### DIFF
--- a/src/openflight/ballistics.py
+++ b/src/openflight/ballistics.py
@@ -49,10 +49,14 @@ AIR_DENSITY_STD = 1.225  # kg/m³ at sea level, 15 °C ISA
 # TrackMan capture (session_logs/OpenFlight-Test.Normalized.csv, 24 shots,
 # differential evolution + Nelder-Mead, rho=1.184 to match TrackMan "Flat").
 # Overall carry RMSE against TrackMan: 24.52 -> 3.97 yd. The previous
-# CL_HALF_SP of 0.15 sat above the entire realistic spin-parameter range
-# (driver Sp ~ 0.08), so the lift curve never left its low-lift regime and
-# driver carry ran ~37 yd short. Resulting Cl at realistic Sp now falls inside
-# the 0.18-0.25 band the cited sources report.
+# CL_HALF_SP of 0.15 sat well above the low-spin driver regime (driver
+# Sp ~ 0.05-0.08), so for drivers the lift curve never left its low-lift
+# regime and driver carry ran ~37 yd short. Irons and wedges (Sp ~ 0.21-0.63)
+# were already past CL_HALF_SP and ran long instead, which is why the error
+# flipped sign by club. Resulting Cl is ~0.13-0.16 for drivers, rising to
+# ~0.22-0.23 for irons and wedges; the iron/wedge values sit inside the
+# 0.18-0.25 band the cited sources report, while the driver values remain
+# below it.
 CD_BASE = 0.19071
 CD_SPIN_COEFF = 0.31588
 CL_SATURATION = 0.25544

--- a/src/openflight/ballistics.py
+++ b/src/openflight/ballistics.py
@@ -44,10 +44,19 @@ AIR_DENSITY_STD = 1.225  # kg/m³ at sea level, 15 °C ISA
 # These are simple parametric forms consistent with Bearman & Harvey (1976)
 # and Kensrud & Smith (2018) for dimpled balls past the drag crisis
 # (Re ~ 5e4–2e5), which covers the full range of realistic golf shots.
-CD_BASE = 0.205
-CD_SPIN_COEFF = 0.18
-CL_SATURATION = 0.32
-CL_HALF_SP = 0.15
+#
+# Fitted with scripts/analysis/sweep_ballistic_coeffs.py against the committed
+# TrackMan capture (session_logs/OpenFlight-Test.Normalized.csv, 24 shots,
+# differential evolution + Nelder-Mead, rho=1.184 to match TrackMan "Flat").
+# Overall carry RMSE against TrackMan: 24.52 -> 3.97 yd. The previous
+# CL_HALF_SP of 0.15 sat above the entire realistic spin-parameter range
+# (driver Sp ~ 0.08), so the lift curve never left its low-lift regime and
+# driver carry ran ~37 yd short. Resulting Cl at realistic Sp now falls inside
+# the 0.18-0.25 band the cited sources report.
+CD_BASE = 0.19071
+CD_SPIN_COEFF = 0.31588
+CL_SATURATION = 0.25544
+CL_HALF_SP = 0.04758
 
 # Exponential spin decay: ω(t) = ω₀·exp(-rate·t).
 # ~4%/s per Kiratidis & Leinweber (2018); small but matters over ~6 s flights.

--- a/tests/test_ballistics.py
+++ b/tests/test_ballistics.py
@@ -1,11 +1,13 @@
 """Tests for the ballistics flight simulator and launch resolution."""
 
+import math
 from datetime import datetime
 
 import pytest
 
 from openflight.ballistics import (
     CLUB_TYPICAL_SPIN_RPM,
+    SPIN_DECAY_RATE,
     LaunchConditions,
     resolve_launch,
     simulate,
@@ -136,10 +138,17 @@ class TestSimulate:
         assert traj.points[-1].t == pytest.approx(traj.flight_time_s, rel=0.01)
 
     def test_spin_decays_over_flight(self):
-        traj = simulate(_driver(spin_rpm=3000))
+        initial_spin = 3000
+        traj = simulate(_driver(spin_rpm=initial_spin))
         final_spin = traj.points[-1].spin_rpm
-        # 4%/s for ~6s flight → ~80% of initial
-        assert 2300 < final_spin < 2900
+
+        # Assert the decay law itself rather than a hardcoded window, so the
+        # test stays valid when aero coefficients change the flight time.
+        expected = initial_spin * math.exp(-SPIN_DECAY_RATE * traj.flight_time_s)
+        assert final_spin == pytest.approx(expected, rel=1e-3)
+
+        # Sanity: spin must fall, but not collapse over a single flight.
+        assert 0.6 * initial_spin < final_spin < initial_spin
 
     def test_flight_time_reasonable(self):
         traj = simulate(_driver())

--- a/tests/test_ballistics_trackman_regression.py
+++ b/tests/test_ballistics_trackman_regression.py
@@ -36,25 +36,24 @@ from validate_ballistics import (  # noqa: E402  (path set up above)
 
 TRACKMAN_CSV = _REPO_ROOT / "session_logs" / "OpenFlight-Test.Normalized.csv"
 
-# Per-club RMSE ceilings in yards, seeded from the measured baseline on
-# c9d0cc7 (2026-08-18) with a small tolerance for float/platform drift:
+# Per-club RMSE ceilings in yards. Ratcheted down after the aero coefficients
+# were re-fit against this same capture (see ballistics.py CD_/CL_ constants).
 #
-#   club              n   rmse    mae    bias
-#   7-iron            9   11.64  11.00  +11.00
-#   driver            8   38.60  37.18  -37.18
-#   pitching wedge    7   13.56  13.16  +11.02
-#   OVERALL          24   24.52  20.36   -5.05
+#                    before re-fit        after re-fit
+#   club            rmse      bias       rmse     bias
+#   7-iron         11.64   +11.00        2.96   +1.52
+#   driver         38.60   -37.18        1.75   -0.45
+#   pitching wedge 13.56   +11.02        6.26   -2.96
+#   OVERALL        24.52    -5.05        3.97   -0.45
 #
-# The driver number is large because Cl is mis-fit at low spin parameter
-# (CL_HALF_SP=0.15 sits above the driver's whole Sp range, so the lift curve
-# never leaves its low-lift regime). Fixing the aero constants should drop
-# driver RMSE substantially -- when it does, lower these ceilings.
+# Ceilings sit slightly above the measured values to absorb float/platform
+# drift. Lower them again if the model improves; never raise them.
 RMSE_BUDGET_YARDS = {
-    "driver": 40.0,
-    "7-iron": 13.0,
-    "pitching wedge": 15.0,
+    "driver": 3.0,
+    "7-iron": 4.0,
+    "pitching wedge": 7.5,
 }
-OVERALL_RMSE_BUDGET_YARDS = 26.0
+OVERALL_RMSE_BUDGET_YARDS = 5.0
 
 # The reference capture is a fixed, committed file: if the shot count changes,
 # the fixture changed and every budget above needs re-deriving.


### PR DESCRIPTION
## What does this PR do?

Re-fits the four aerodynamic coefficients in `ballistics.py` against the committed TrackMan reference capture, using the in-repo optimizer. Overall carry RMSE against that capture drops from **24.52 to 3.97 yd (-83.8%)**.

Three files, Python only:
- `src/openflight/ballistics.py` - the four constants, plus a comment recording the fit provenance
- `tests/test_ballistics_trackman_regression.py` - ratchet the budgets down to the new baseline
- `tests/test_ballistics.py` - fix `test_spin_decays_over_flight` (explained below)

Follow-up to #218. Branch is cut fresh from current `main` per your note about drift since #169.

## Why was this required?

Fed TrackMan's own measured launch conditions, carry error was large and club-dependent: driver ~37 yd short, irons and wedges ~11 yd long.

Root cause is `CL_HALF_SP = 0.15`. That is the spin parameter at which `Cl` reaches half its saturation value, and it sits **well above the low-spin driver regime** (`Sp ≈ 0.05-0.08`). A driver at `Sp ≈ 0.08` lands at `Cl ≈ 0.11`, so for drivers the lift curve never left its low-lift regime. Irons and wedges (`Sp ≈ 0.21-0.63`) were already past `CL_HALF_SP` and ran long instead, which is exactly why the error flipped sign by club.

## How the numbers were produced

`scripts/analysis/sweep_ballistic_coeffs.py`, differential evolution then Nelder-Mead, `rho=1.184` to match TrackMan "Flat". Converged in 1968 evaluations.

```
CD_BASE        0.205  -> 0.19071
CD_SPIN_COEFF  0.18   -> 0.31588
CL_SATURATION  0.32   -> 0.25544
CL_HALF_SP     0.15   -> 0.04758
```

| club | RMSE before -> after | bias before -> after |
|---|---|---|
| driver | 38.60 -> **1.75** | -37.18 -> **-0.45** |
| 7-iron | 11.64 -> **2.96** | +11.00 -> +1.52 |
| pitching wedge | 13.56 -> **6.26** | +11.02 -> -2.96 |
| **OVERALL** | 24.52 -> **3.97** | -5.05 -> -0.45 |

## Evidence this is a physics correction, not a curve fit

Fitting 4 parameters to 24 shots invites overfitting, so I checked it four ways the optimizer never saw.

**1. Literature agreement.** Fitted `Cl` now falls inside the cited 0.18-0.25 band **for irons and wedges**. Driver `Cl` (0.13-0.16) remains below that band - the band as cited is not a whole-range claim, and the driver figures below make that explicit:

```
shot            Sp      Cl      Cd
driver PGA     0.081   0.161   0.216
driver amateur 0.073   0.155   0.214
7-iron         0.271   0.217   0.276
pitching wedge 0.474   0.232   0.340
```

**2. Independent physical indicators not fitted for.** Driver landing angle **30.8 -> 40.0 deg** (real drivers land 38-42) and apex to 36 yd. The old shallow landing angle was the classic under-lift signature.

**3. Cross-validation.**

- **Leave-one-shot-out (24 refits): mean |error| 2.99 yd**, below the in-sample 3.97. No overfitting to individual shots.
- **Leave-one-club-out looks bad for driver (36.01 yd held-out) and I want to be upfront about why.** The capture has **zero spin-parameter overlap between clubs**: driver `Sp` 0.050-0.078, 7-iron 0.212-0.254, wedge 0.376-0.632. Holding out driver removes the only data constraining `CL_HALF_SP` in the low-`Sp` regime, so that test demands extrapolation into an unsampled region. It is a coverage limit of a 3-club capture, not overfitting.
- **A driver 2-fold split that keeps low-`Sp` in training confirms this:** held-out drivers score **2.98** and **7.82 yd** (shipped scores 36.80 and 40.33 on the same shots), and `CL_HALF_SP` lands at 0.0505 / 0.0373 across independent folds - nowhere near 0.15.

**4. Agreement with an independent published fit.** Ferguson, McNally & McPhee (2022, ISEA 14, open access - the baseline the CVPR 2023 paper compares against) fitted `CD = a+bS+cS²`, `CL = d+eS+fS²` to **N=1040 shots** (GCQuad + FlightScope X3, Titleist Pro V1), achieving 2.74 yd carry MAE. Mean |difference| against their curves:

| regime | CL ours | CL shipped | CD ours | CD shipped |
|---|---|---|---|---|
| driver, S 0.02-0.10 | **0.0187** | 0.0293 | **0.0270** | 0.0331 |
| iron, S 0.20-0.30 | **0.0637** | 0.0787 | **0.0404** | 0.0599 |
| full, S 0.02-0.75 | 0.0825 | **0.0817** | **0.0331** | 0.0619 |

In both regimes where this capture has data, the re-fit moves closer to that independent fit on all four measures.

## Known limitations - please read before merging

1. **One 24-shot session, 3 clubs, one player, one ball model.** It is all the paired ground truth in the repo. If you have a second capture I would happily refit and validate across sessions - `sweep_ballistic_coeffs.py` has a `--loso` flag, so I assume that was the intent.
2. **No mid-`Sp` data.** Ranges 0.08-0.21 and 0.25-0.38 are empty. A 5-iron or hybrid capture is the single most valuable next data point.
3. **Wedges remain the weakest column** (RMSE 6.26, `Cd` 0.340 at `Sp≈0.47` above the ~0.21-0.27 literature range, one 15.97 yd outlier). This is a **functional-form limit, not a fit limit**: the Hill form `CL_SAT·S/(CL_HALF+S)` is monotonic and can only flatten, while measured `Cl` peaks near `S≈0.5` then falls. Swapping in a quadratic reaches 1.99 yd overall / 3.33 yd on wedges on the same data. I will file that separately rather than expand this PR.

## AI assistance disclosure

Per the new [AI-POLICY.md](https://github.com/jewbetcha/openflight/blob/main/AI-POLICY.md): AI assistance was used for this change. It ran the in-repo optimizer, the cross-validation splits, and drafted the provenance comment and this description. I directed the work, reviewed every changed line, independently re-ran `validate_ballistics.py` to reproduce the numbers outside the optimizer's own scoring path, hand-checked `Cl`/`Cd` at four spin parameters against the literature, and verified the tightened budget still fails on a deliberately reverted constant. The four coefficients are machine-fitted output; every claim made about them here was checked against the repository and the cited sources.

## Automated tests

No new test file - the guard from #219 already existed and did its job. Its budgets were seeded at the *old* error, so it went red immediately; that is the ratchet working. Lowered: overall 26.0 -> **5.0**, driver 40.0 -> **3.0**, 7-iron 13.0 -> **4.0**, wedge 15.0 -> **7.5**, with the before/after table in the module comment.

`test_spin_decays_over_flight` needed a real fix. It asserted `2300 < final_spin < 2900` against an assumed ~6 s flight. A correctly-lifted ball now flies 6.92 s and decays to 2274.6 rpm - which matches the decay law exactly (`3000·e^(-0.04·6.919) = 2274.7`), so this was a stale literal rather than a regression. It now asserts the **law** (`pytest.approx`, rel=1e-3) plus a loose sanity band, so it stays valid through future coefficient changes instead of needing another manual edit.

## Manual (human) testing

- Applied the coefficients and **independently re-ran `validate_ballistics.py`**, reproducing the sweep's numbers exactly (3.97 yd overall, driver bias -0.45) - so the improvement is not an artifact of the optimizer's own scoring path.
- **Verified the tightened budget can still fail:** reverted `CL_HALF_SP` to 0.15 and confirmed it goes red loudly - `driver: carry RMSE 54.25 yd exceeds budget 3.0 yd`. A budget that cannot go red is worthless.
- Hand-computed `Cl`/`Cd` at four realistic spin parameters against the literature (table above).
- Confirmed the spin-decay figure against the closed-form decay law before touching that test.
- Ran the leave-one-out and 2-fold cross-validations described above.
- Full suite: **1327 passed, 8 skipped** - zero failures.

Caveat: I only have Python 3.13/3.14 locally, so the 3.10-3.12 matrix is unverified on my side. The change is pure float arithmetic so I expect no version sensitivity, and CI will confirm (it did for #219).

## Checklist

- [x] **Single feature/fix** - the aero constants, plus the two test updates the change forces
- [x] **Automated tests included** - updated guard + fixed decay test
- [x] **Manual testing described**
- [x] Python tests pass - 1327 passed, 8 skipped
- [x] Pylint passes - 9.70/10 (unchanged; no behavioural source touched beyond constants)
- [x] Ruff `check` passes on all three files
- [ ] UI builds / UI lint - n/a, no UI changes
- [x] No unrelated changes mixed in

One note: `ruff format --check` flags `ballistics.py`, but those complaints are **pre-existing on `main`** (verified by stashing) in code this PR does not touch. I left them rather than mix a formatting sweep into a physics change - happy to send that separately.


