### PR TITLE
fix: lock camera exposure after startup

### DIFF
--- a/docs/camera/README.md
+++ b/docs/camera/README.md
@@ -238,16 +238,10 @@ inside the configured frame period.
 At startup, the controller begins with the last good setting saved for the same
 resolution and frame rate. If that setting is not usable, it can jump several
 steps and recheck after `300 ms`, rather than waiting through one five-second
-step at a time. It makes at most three fast startup adjustments.
-
-After startup, the controller:
-
-- Samples the latest stable frame every five seconds.
-- Requires two consecutive bad samples before changing a setting.
-- Moves only one validated step during normal operation.
-- Waits ten seconds after a steady-state adjustment.
-- Defers changes while a triggered post-impact camera tail is being collected.
-- Recovers automatically when lighting improves.
+step at a time. It makes at most three fast startup adjustments before shot
+capture is armed. The selected manual exposure and gain are then locked for the
+life of that camera runtime, so every replay in the session uses the same image
+controls. There is no periodic exposure monitoring after startup.
 
 The last good setting is stored at:
 
@@ -260,7 +254,8 @@ stop the camera. Preview and raw frame capture continue, but camera-assisted
 horizontal launch, Club Path, and Attack Angle are withheld for that shot.
 Horizontal launch falls back to the IWR6843 path. The Camera tab reports
 **Lighting needed** and **Radar fallback active** so the operator can add or
-redirect light without restarting the session.
+redirect light. Restart OpenFlight after changing the lighting so startup
+calibration can select and lock a new setting.
 
 The standalone calibration sweep remains useful when diagnosing an unusual
 lighting installation:

--- a/src/openflight/camera/auto_exposure.py
+++ b/src/openflight/camera/auto_exposure.py
@@ -17,7 +17,6 @@ ExposureQualityStatus = Literal[
 ]
 ExposureRecommendation = Literal["brighter", "darker", "hold"]
 AutoExposureStatus = Literal[
-    "calibrating",
     "ready",
     "adjusting",
     "lighting_required",
@@ -173,7 +172,7 @@ def measure_exposure(image: np.ndarray) -> ExposureObservation:
     else:
         status = "marginal"
         recommendation = "darker" if clipped_pct > 2.0 or median > 180.0 else "brighter"
-        message = f"Exposure is usable; monitoring for a {recommendation} adjustment"
+        message = f"Exposure is usable; a {recommendation} setting may improve contrast"
 
     return ExposureObservation(
         sample_available=True,
@@ -199,36 +198,31 @@ def motion_blur_risk(exposure_us: int) -> Literal["low", "elevated", "high"]:
 
 
 class AutoExposurePolicy:
-    """Choose startup jumps and conservative steady-state adjustments."""
+    """Choose startup exposure steps and lock the first terminal decision."""
 
     def __init__(
         self,
         *,
         fps: float,
         startup_max_adjustments: int = 3,
-        steady_confirmations: int = 2,
     ):
         if startup_max_adjustments < 1:
             raise ValueError("startup_max_adjustments must be positive")
-        if steady_confirmations < 1:
-            raise ValueError("steady_confirmations must be positive")
         self.steps = exposure_steps_for_fps(fps)
         self.startup_max_adjustments = startup_max_adjustments
-        self.steady_confirmations = steady_confirmations
-        self._fast_reacquire_armed = False
-        self._reset_startup_state()
-
-    def _reset_startup_state(self) -> None:
-        """Enter startup convergence without rearming scene-change detection."""
         self._startup = True
         self._startup_adjustments = 0
-        self._pending_recommendation: ExposureRecommendation = "hold"
-        self._pending_count = 0
+        self._locked_decision: AutoExposureDecision | None = None
+
+    def _reset_startup_state(self) -> None:
+        """Enter startup convergence and clear any prior locked result."""
+        self._startup = True
+        self._startup_adjustments = 0
+        self._locked_decision: AutoExposureDecision | None = None
 
     def reset(self) -> None:
-        """Restart fast convergence after a material scene change."""
+        """Unlock the policy for a new camera startup."""
         self._reset_startup_state()
-        self._fast_reacquire_armed = False
 
     @property
     def startup(self) -> bool:
@@ -243,6 +237,9 @@ class AutoExposurePolicy:
         gain: float,
     ) -> AutoExposureDecision:
         """Return the next camera-control decision without applying it."""
+        if self._locked_decision is not None:
+            return self._locked_decision
+
         current_index = self._nearest_step_index(exposure_us, gain)
         current_step = self.steps[current_index]
         risk = motion_blur_risk(current_step.exposure_us)
@@ -259,36 +256,16 @@ class AutoExposurePolicy:
         if observation.acceptable:
             self._startup = False
             self._startup_adjustments = 0
-            self._pending_recommendation = "hold"
-            self._pending_count = 0
-            self._fast_reacquire_armed = True
-            return AutoExposureDecision(
+            self._locked_decision = AutoExposureDecision(
                 status="ready",
                 analysis_eligible=True,
                 message=observation.message,
                 observation=observation,
                 motion_blur_risk=risk,
             )
+            return self._locked_decision
 
-        if self._startup:
-            return self._startup_decision(observation, current_index)
-        if self._fast_reacquire_armed and self._is_material_change(
-            observation,
-            current_index,
-        ):
-            self._reset_startup_state()
-            self._fast_reacquire_armed = False
-            return self._startup_decision(observation, current_index)
-        return self._steady_decision(observation, current_index)
-
-    def _is_material_change(
-        self,
-        observation: ExposureObservation,
-        current_index: int,
-    ) -> bool:
-        """Return whether the measured scene needs a multi-step correction."""
-        target_index = self._startup_target_index(observation, current_index)
-        return abs(target_index - current_index) >= 2
+        return self._startup_decision(observation, current_index)
 
     def _startup_decision(
         self,
@@ -299,24 +276,26 @@ class AutoExposurePolicy:
         risk = motion_blur_risk(current.exposure_us)
         if self._startup_adjustments >= self.startup_max_adjustments:
             self._startup = False
-            return AutoExposureDecision(
+            self._locked_decision = AutoExposureDecision(
                 status="lighting_required",
                 analysis_eligible=False,
                 message=self._lighting_message(observation),
                 observation=observation,
                 motion_blur_risk=risk,
             )
+            return self._locked_decision
 
         target_index = self._startup_target_index(observation, current_index)
         if target_index == current_index:
             self._startup = False
-            return AutoExposureDecision(
+            self._locked_decision = AutoExposureDecision(
                 status="lighting_required",
                 analysis_eligible=False,
                 message=self._lighting_message(observation),
                 observation=observation,
                 motion_blur_risk=risk,
             )
+            return self._locked_decision
 
         self._startup_adjustments += 1
         target = self.steps[target_index]
@@ -327,51 +306,6 @@ class AutoExposurePolicy:
                 "Calibrating camera exposure "
                 f"({self._startup_adjustments}/{self.startup_max_adjustments})"
             ),
-            observation=observation,
-            target=target,
-            motion_blur_risk=motion_blur_risk(target.exposure_us),
-        )
-
-    def _steady_decision(
-        self,
-        observation: ExposureObservation,
-        current_index: int,
-    ) -> AutoExposureDecision:
-        if observation.recommendation != self._pending_recommendation:
-            self._pending_recommendation = observation.recommendation
-            self._pending_count = 1
-        else:
-            self._pending_count += 1
-
-        current = self.steps[current_index]
-        risk = motion_blur_risk(current.exposure_us)
-        if self._pending_count < self.steady_confirmations:
-            return AutoExposureDecision(
-                status="calibrating",
-                analysis_eligible=False,
-                message="Confirming the lighting change before adjusting",
-                observation=observation,
-                motion_blur_risk=risk,
-            )
-
-        direction = 1 if observation.recommendation == "brighter" else -1
-        target_index = max(0, min(len(self.steps) - 1, current_index + direction))
-        self._pending_count = 0
-        self._pending_recommendation = "hold"
-        if target_index == current_index:
-            return AutoExposureDecision(
-                status="lighting_required",
-                analysis_eligible=False,
-                message=self._lighting_message(observation),
-                observation=observation,
-                motion_blur_risk=risk,
-            )
-
-        target = self.steps[target_index]
-        return AutoExposureDecision(
-            status="adjusting",
-            analysis_eligible=False,
-            message=f"Adjusting camera {observation.recommendation}",
             observation=observation,
             target=target,
             motion_blur_risk=motion_blur_risk(target.exposure_us),

--- a/src/openflight/camera/capture_runtime.py
+++ b/src/openflight/camera/capture_runtime.py
@@ -39,9 +39,7 @@ CameraCaptureStream = Literal["raw", "main-y"]
 
 RASPBERRY_PI_DIST_PACKAGES = Path("/usr/lib/python3/dist-packages")
 OV9281_VERTICAL_OFFSET_PATH = Path("/sys/module/ov9282/parameters/strip_y_offset")
-AUTO_EXPOSURE_SAMPLE_INTERVAL_S = 5.0
 AUTO_EXPOSURE_STARTUP_SETTLE_S = 0.3
-AUTO_EXPOSURE_ADJUSTMENT_COOLDOWN_S = 10.0
 
 
 def vertical_crop_limits(width: int, height: int) -> dict[str, int] | None:
@@ -175,7 +173,6 @@ class CameraCaptureRuntime:
         self._reconfigure_lock = threading.Lock()
         self._auto_exposure_policy = AutoExposurePolicy(fps=self.settings.fps)
         self._auto_exposure_stop = threading.Event()
-        self._auto_exposure_worker: threading.Thread | None = None
         self._auto_exposure_lock = threading.Lock()
         self._auto_exposure_decision = AutoExposureDecision(
             status="unavailable",
@@ -235,6 +232,7 @@ class CameraCaptureRuntime:
             self._wait_for_prebuffer()
             if self.settings.auto_exposure:
                 self._start_auto_exposure()
+                self._refill_locked_exposure_prebuffer()
             if self._use_gpio_trigger:
                 self._start_gpio_trigger()
         except Exception:
@@ -254,9 +252,6 @@ class CameraCaptureRuntime:
         """Stop camera capture and release hardware resources."""
         self._running = False
         self._auto_exposure_stop.set()
-        if self._auto_exposure_worker is not None:
-            self._auto_exposure_worker.join(timeout=3.0)
-            self._auto_exposure_worker = None
         if self._button is not None:
             self._button.close()
             self._button = None
@@ -538,35 +533,43 @@ class CameraCaptureRuntime:
                 f"{self._ring.buffered_frames}/{self.settings.pre_frames} pre-trigger frames"
             )
 
+    def _refill_locked_exposure_prebuffer(self) -> None:
+        """Discard calibration frames and refill the ring at locked controls."""
+        self._ring = TriggeredFrameBuffer(
+            self.settings.pre_frames,
+            self.settings.post_frames,
+        )
+        self._wait_for_prebuffer()
+
     def _start_auto_exposure(self) -> None:
-        """Start non-blocking exposure calibration and monitoring."""
+        """Calibrate once before arming shot capture, then lock the controls."""
         self._auto_exposure_policy.reset()
         self._auto_exposure_stop.clear()
-        self._auto_exposure_worker = threading.Thread(
-            target=self._auto_exposure_loop,
-            name="camera-auto-exposure",
-            daemon=True,
-        )
-        self._auto_exposure_worker.start()
+        self._auto_exposure_loop()
 
     def _auto_exposure_loop(self) -> None:
-        delay_s = 0.0
-        while self._running and not self._auto_exposure_stop.wait(delay_s):
+        """Converge startup controls and return without steady-state monitoring."""
+        while self._running and not self._auto_exposure_stop.is_set():
             try:
                 decision = self._run_auto_exposure_cycle()
             except Exception:  # pylint: disable=broad-exception-caught
-                logger.warning("[CAMERA] Automatic exposure check failed", exc_info=True)
-                delay_s = AUTO_EXPOSURE_SAMPLE_INTERVAL_S
-                continue
+                logger.warning("[CAMERA] Startup exposure calibration failed", exc_info=True)
+                return
 
             if decision is None:
-                delay_s = 0.1
-            elif decision.should_apply and self._auto_exposure_policy.startup:
-                delay_s = AUTO_EXPOSURE_STARTUP_SETTLE_S
-            elif decision.should_apply:
-                delay_s = AUTO_EXPOSURE_ADJUSTMENT_COOLDOWN_S
-            else:
-                delay_s = AUTO_EXPOSURE_SAMPLE_INTERVAL_S
+                if self._auto_exposure_stop.wait(0.1):
+                    return
+                continue
+            if not decision.should_apply:
+                logger.info(
+                    "[CAMERA] Startup exposure locked: %dus gain %.1f (%s)",
+                    self.settings.exposure_us,
+                    self.settings.gain,
+                    decision.status,
+                )
+                return
+            if self._auto_exposure_stop.wait(AUTO_EXPOSURE_STARTUP_SETTLE_S):
+                return
 
     def _run_auto_exposure_cycle(self) -> AutoExposureDecision | None:
         """Measure one stable frame and apply the policy's requested control step."""

--- a/src/openflight/server.py
+++ b/src/openflight/server.py
@@ -4465,13 +4465,13 @@ def main():
         "--camera-capture-exposure-us",
         type=int,
         default=1000,
-        help="Manual exposure fallback; the Camera tab can switch out of automatic mode.",
+        help="Exposure seed used by the one-time startup calibration.",
     )
     parser.add_argument(
         "--camera-capture-gain",
         type=float,
         default=4.0,
-        help="Manual gain fallback; the Camera tab can switch out of automatic mode.",
+        help="Analogue-gain seed used by the one-time startup calibration.",
     )
     parser.add_argument(
         "--camera-capture-mount-height-m",

--- a/tests/test_camera_auto_exposure.py
+++ b/tests/test_camera_auto_exposure.py
@@ -106,37 +106,35 @@ def test_acceptable_startup_observation_marks_analysis_ready():
     assert not decision.should_apply
 
 
-def test_steady_state_requires_confirmation_and_moves_one_step():
-    policy = AutoExposurePolicy(fps=488.0, steady_confirmations=2)
-    policy.evaluate(observation("good", "hold"), exposure_us=650, gain=15.0)
-    bad = observation("too_dark", "brighter", median=70.0, p90=74.0)
+def test_ready_setting_stays_locked_until_the_next_startup():
+    policy = AutoExposurePolicy(fps=488.0)
+    ready = policy.evaluate(
+        observation("good", "hold"),
+        exposure_us=500,
+        gain=12.0,
+    )
 
-    first = policy.evaluate(bad, exposure_us=650, gain=15.0)
-    second = policy.evaluate(bad, exposure_us=650, gain=15.0)
-
-    assert first.status == "calibrating"
-    assert not first.should_apply
-    assert second.status == "adjusting"
-    assert second.target == EXPOSURE_STEPS[11]
-
-
-def test_material_steady_state_change_reenters_fast_convergence():
-    policy = AutoExposurePolicy(fps=488.0, steady_confirmations=2)
-    policy.evaluate(observation("good", "hold"), exposure_us=500, gain=12.0)
-
-    decision = policy.evaluate(
+    changed_scene = policy.evaluate(
+        observation("too_dark", "brighter", median=18.0, p90=40.0),
+        exposure_us=500,
+        gain=12.0,
+    )
+    policy.reset()
+    next_startup = policy.evaluate(
         observation("too_dark", "brighter", median=18.0, p90=40.0),
         exposure_us=500,
         gain=12.0,
     )
 
-    assert decision.status == "adjusting"
-    assert decision.should_apply
-    assert decision.target.signal > EXPOSURE_STEPS[9].signal
+    assert changed_scene is ready
+    assert changed_scene.status == "ready"
+    assert not changed_scene.should_apply
+    assert next_startup.status == "adjusting"
+    assert next_startup.should_apply
     assert policy.startup is True
 
 
-def test_ladder_limit_requires_lighting_but_recovers_automatically():
+def test_ladder_limit_stays_locked_until_the_next_startup():
     policy = AutoExposurePolicy(fps=488.0)
     darkest = EXPOSURE_STEPS[-1]
 
@@ -145,6 +143,12 @@ def test_ladder_limit_requires_lighting_but_recovers_automatically():
         exposure_us=darkest.exposure_us,
         gain=darkest.gain,
     )
+    locked = policy.evaluate(
+        observation("marginal", "brighter", median=40.0, p90=95.0),
+        exposure_us=darkest.exposure_us,
+        gain=darkest.gain,
+    )
+    policy.reset()
     recovered = policy.evaluate(
         observation("marginal", "brighter", median=40.0, p90=95.0),
         exposure_us=darkest.exposure_us,
@@ -154,6 +158,7 @@ def test_ladder_limit_requires_lighting_but_recovers_automatically():
     assert failed.status == "lighting_required"
     assert failed.analysis_eligible is False
     assert "add or redirect light" in failed.message
+    assert locked is failed
     assert recovered.status == "ready"
     assert recovered.analysis_eligible is True
 
@@ -171,35 +176,6 @@ def test_startup_attempt_limit_requires_lighting_change():
 
     assert failed.status == "lighting_required"
     assert not failed.should_apply
-
-
-def test_lighting_failure_can_recover_with_steady_state_adjustment():
-    policy = AutoExposurePolicy(fps=488.0, startup_max_adjustments=1)
-    dark = observation("too_dark", "brighter", median=18.0, p90=40.0)
-    first = policy.evaluate(dark, exposure_us=250, gain=4.0)
-    failed = policy.evaluate(
-        dark,
-        exposure_us=first.target.exposure_us,
-        gain=first.target.gain,
-    )
-    bright = observation("too_bright", "darker", median=240.0, p90=255.0)
-
-    confirming = policy.evaluate(
-        bright,
-        exposure_us=first.target.exposure_us,
-        gain=first.target.gain,
-    )
-    recovered = policy.evaluate(
-        bright,
-        exposure_us=first.target.exposure_us,
-        gain=first.target.gain,
-    )
-
-    assert failed.status == "lighting_required"
-    assert policy.startup is False
-    assert confirming.status == "calibrating"
-    assert recovered.should_apply
-    assert recovered.target.signal < first.target.signal
 
 
 @pytest.mark.parametrize(

--- a/tests/test_camera_triggered_buffer.py
+++ b/tests/test_camera_triggered_buffer.py
@@ -35,6 +35,16 @@ def make_frame(index: int, interval_ns: int = 4_000_000) -> CameraFrame:
     )
 
 
+def make_good_exposure_image() -> np.ndarray:
+    """Create a frame with usable contrast in the impact-area ROI."""
+    image = np.full((200, 320), 110, dtype=np.uint8)
+    image[100:175, 90:230] = np.tile(
+        np.linspace(45, 185, 140, dtype=np.uint8),
+        (75, 1),
+    )
+    return image
+
+
 def test_ring_freezes_latest_pre_frames_and_post_tail():
     ring = TriggeredFrameBuffer(pre_trigger_frames=3, post_trigger_frames=2)
     for index in range(5):
@@ -365,11 +375,7 @@ def test_auto_exposure_acceptable_frame_enables_camera_analysis(tmp_path):
     )
     runtime._camera = object()
     runtime._running = True
-    image = np.full((200, 320), 110, dtype=np.uint8)
-    image[100:175, 90:230] = np.tile(
-        np.linspace(45, 185, 140, dtype=np.uint8),
-        (75, 1),
-    )
+    image = make_good_exposure_image()
     runtime._ring.add_frame(
         CameraFrame(
             image=image,
@@ -386,6 +392,97 @@ def test_auto_exposure_acceptable_frame_enables_camera_analysis(tmp_path):
     assert decision.status == "ready"
     assert runtime.camera_analysis_eligible is True
     assert runtime.auto_exposure_status()["observation"]["status"] == "good"
+
+
+def test_auto_exposure_locks_first_acceptable_startup_setting(tmp_path):
+    class FakeCamera:
+        def __init__(self):
+            self.controls = []
+
+        def set_controls(self, controls):
+            self.controls.append(controls)
+
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(fps=488.0, exposure_us=500, gain=12.0),
+    )
+    runtime._camera = FakeCamera()
+    runtime._running = True
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=make_good_exposure_image(),
+            sensor_timestamp_ns=1,
+            host_timestamp_ns=2,
+            exposure_us=500,
+            analogue_gain=12.0,
+        )
+    )
+    startup_decision = runtime._run_auto_exposure_cycle()
+
+    runtime._ring.add_frame(
+        CameraFrame(
+            image=np.full((200, 320), 18, dtype=np.uint8),
+            sensor_timestamp_ns=3,
+            host_timestamp_ns=4,
+            exposure_us=500,
+            analogue_gain=12.0,
+        )
+    )
+    later_decision = runtime._run_auto_exposure_cycle()
+
+    assert startup_decision is not None
+    assert startup_decision.status == "ready"
+    assert later_decision == startup_decision
+    assert runtime._camera.controls == []
+    assert (runtime.settings.exposure_us, runtime.settings.gain) == (500, 12.0)
+
+
+def test_auto_exposure_startup_calibration_is_synchronous(tmp_path, monkeypatch):
+    calibration_started = threading.Event()
+    allow_calibration_to_finish = threading.Event()
+    startup_returned = threading.Event()
+    runtime = CameraCaptureRuntime(output_dir=tmp_path)
+
+    def calibrate():
+        calibration_started.set()
+        assert allow_calibration_to_finish.wait(timeout=1.0)
+
+    monkeypatch.setattr(runtime, "_auto_exposure_loop", calibrate)
+
+    def start_auto_exposure():
+        runtime._start_auto_exposure()
+        startup_returned.set()
+
+    startup_thread = threading.Thread(target=start_auto_exposure)
+    startup_thread.start()
+    assert calibration_started.wait(timeout=1.0)
+    returned_before_calibration = startup_returned.wait(timeout=0.05)
+    allow_calibration_to_finish.set()
+    startup_thread.join(timeout=1.0)
+
+    assert returned_before_calibration is False
+    assert startup_returned.is_set()
+
+
+def test_auto_exposure_discards_calibration_frames_before_arming(tmp_path, monkeypatch):
+    runtime = CameraCaptureRuntime(
+        output_dir=tmp_path,
+        settings=CameraCaptureSettings(fps=100.0, pre_ms=20.0, post_ms=10.0),
+    )
+    runtime._ring.add_frame(make_frame(1))
+    runtime._ring.add_frame(make_frame(2))
+    calibration_ring = runtime._ring
+    buffered_when_refill_started = []
+    monkeypatch.setattr(
+        runtime,
+        "_wait_for_prebuffer",
+        lambda: buffered_when_refill_started.append(runtime._ring.buffered_frames),
+    )
+
+    runtime._refill_locked_exposure_prebuffer()
+
+    assert runtime._ring is not calibration_ring
+    assert buffered_when_refill_started == [0]
 
 
 def test_auto_exposure_restores_last_good_controls_for_same_camera_mode(tmp_path):
@@ -467,11 +564,7 @@ def test_auto_exposure_persists_good_controls(tmp_path):
     )
     runtime._camera = object()
     runtime._running = True
-    image = np.full((200, 320), 110, dtype=np.uint8)
-    image[100:175, 90:230] = np.tile(
-        np.linspace(45, 185, 140, dtype=np.uint8),
-        (75, 1),
-    )
+    image = make_good_exposure_image()
     runtime._ring.add_frame(
         CameraFrame(
             image=image,

--- a/ui/src/components/CameraFeed.test.tsx
+++ b/ui/src/components/CameraFeed.test.tsx
@@ -73,6 +73,8 @@ describe('CameraFeed', () => {
     expect(html).toContain('camera-feed__workspace');
     expect(html).toContain('Camera setup');
     expect(html).toContain('Automatic exposure');
+    expect(html).toContain('calibrates once at startup');
+    expect(html).not.toContain('checks every 5 seconds');
     expect(html).toContain('Auto exposure');
     expect(html).toContain('camera-feed__exposure-quality');
     expect(html).toContain('Camera analysis active');

--- a/ui/src/components/CameraFeed.tsx
+++ b/ui/src/components/CameraFeed.tsx
@@ -41,7 +41,6 @@ interface ExposureQuality {
 }
 
 const AUTO_EXPOSURE_LABELS: Record<CameraAutoExposureStatus['status'], string> = {
-  calibrating: 'Checking',
   ready: 'Ready',
   adjusting: 'Adjusting',
   lighting_required: 'Lighting needed',
@@ -105,7 +104,7 @@ function CaptureSettingsPanel({ settings, exposureQuality, error, onUpdate }: Ca
         <section className="camera-settings__section">
           <div className="camera-settings__section-title">
             <span>Automatic exposure</span>
-            <small>checks every 5 seconds</small>
+            <small>calibrates once at startup</small>
           </div>
           <div
             className={`camera-settings__auto-status camera-settings__auto-status--${autoExposure?.status ?? 'unavailable'}`}

--- a/ui/src/stores/useCameraStore.ts
+++ b/ui/src/stores/useCameraStore.ts
@@ -41,7 +41,7 @@ export interface CameraCaptureSettings {
 
 export interface CameraAutoExposureStatus {
   enabled: boolean;
-  status: 'calibrating' | 'ready' | 'adjusting' | 'lighting_required' | 'unavailable';
+  status: 'ready' | 'adjusting' | 'lighting_required' | 'unavailable';
   analysis_eligible: boolean;
   message: string;
   motion_blur_risk: 'low' | 'elevated' | 'high';


### PR DESCRIPTION
## What does this PR do?

- Runs automatic exposure calibration synchronously once during camera startup.
- Locks the first terminal exposure decision and its manual exposure/gain controls for the lifetime of the camera runtime.
- Removes the periodic five-second exposure monitor and steady-state adjustment path.
- Discards calibration frames and refills the pre-trigger buffer at the locked settings before GPIO shot capture is armed.
- Updates the Camera tab, CLI descriptions, and camera documentation to describe the startup-only behavior.

## Why was this required?

Exposure could change after startup as ambient conditions varied. That made otherwise similar camera replays alternate between analysis-eligible and rejected, and a replay could contain pre-trigger frames captured across different calibration settings. A single startup calibration makes replay quality deterministic for the session. Operators can restart OpenFlight after a material lighting change to select a new locked setting.

## Behavior and tradeoff

Startup may take up to three fast exposure steps plus one pre-trigger-buffer refill before the trigger is armed. In exchange, no shot is accepted until calibration is complete and every replay in that runtime uses one fixed exposure/gain pair.

## Automated tests

- Proves an accepted startup setting remains locked when later frames become dark.
- Proves a lighting-required result remains locked until the next runtime reset.
- Proves startup waits for calibration instead of launching a background monitor.
- Proves calibration frames are discarded before the locked pre-trigger buffer is filled.
- Isolated camera exposure/runtime suite: 52 passed.
- Ruff check and format verification pass on all changed Python files.

## Manual (human) testing

- Real camera hardware was not available locally; final validation on the OV9281/Pi capture stack remains pending.

## Checklist

- [x] Single feature/fix
- [x] Automated tests included
- [x] Documentation updated
- [x] No new dependencies
- [x] No unrelated performance-pipeline changes
