### PR TITLE
fix: keep live metric subtitles readable

### DIFF
--- a/ui/src/components/panel/liveMetrics.test.ts
+++ b/ui/src/components/panel/liveMetrics.test.ts
@@ -171,14 +171,14 @@ describe('buildLiveMetrics', () => {
     expect(byId(metrics, 'club_aoa')).toMatchObject({
       value: '-4.2',
       unit: '°',
-      subtext: 'camera fused (experimental)',
+      subtext: 'camera fused',
       confidence: 'medium',
       confidenceLabel: 'experimental',
     });
     expect(byId(metrics, 'club_path')).toMatchObject({
       value: '+3.1',
       unit: '°',
-      subtext: 'camera fused (experimental)',
+      subtext: 'camera fused',
       confidence: 'high',
       confidenceLabel: 'experimental',
     });
@@ -216,7 +216,10 @@ describe('buildLiveMetrics', () => {
       emptySwingStats
     );
 
-    expect(byId(metrics, 'launch_h').subtext).toBe('camera assisted (experimental)');
+    expect(byId(metrics, 'launch_h')).toMatchObject({
+      subtext: 'camera assisted',
+      confidenceLabel: 'experimental',
+    });
   });
 
   it('marks estimated launch and spin with a flag, not provenance subtext', () => {

--- a/ui/src/components/panel/liveMetrics.ts
+++ b/ui/src/components/panel/liveMetrics.ts
@@ -76,6 +76,7 @@ function buildBallStrikeMetrics(shot: Shot, unitSystem: UnitSystem): LiveMetric[
   const carry = shot.carry_spin_adjusted ?? shot.estimated_carry_yards;
   const angleConfidence = launchAngleQuality(shot.launch_angle_confidence);
   const angleEstimated = shot.angle_source === 'estimated';
+  const horizontalLaunchIsCameraAssisted = shot.launch_angle_horizontal_source === 'camera_assisted_experimental';
   const fusedDeliveryAttempted = shot.experimental_fused_status != null;
   const attackAngle =
     shot.club_angle_deg ??
@@ -139,12 +140,10 @@ function buildBallStrikeMetrics(shot: Shot, unitSystem: UnitSystem): LiveMetric[
       label: t('metric.hLaunch'),
       value: formatOptionalAngle(shot.launch_angle_horizontal, true),
       unit: angleUnit(shot.launch_angle_horizontal),
-      subtext:
-        shot.launch_angle_horizontal_source === 'camera_assisted_experimental'
-          ? 'camera assisted (experimental)'
-          : undefined,
+      subtext: horizontalLaunchIsCameraAssisted ? 'camera assisted' : undefined,
       estimated: markEstimated(shot.launch_angle_horizontal !== null && angleEstimated),
       confidence: shot.launch_angle_horizontal === null ? null : angleConfidence,
+      confidenceLabel: horizontalLaunchIsCameraAssisted ? 'experimental' : undefined,
     },
     {
       id: 'spin',
@@ -171,7 +170,7 @@ function buildBallStrikeMetrics(shot: Shot, unitSystem: UnitSystem): LiveMetric[
           ? undefined
           : fusedDeliveryAttempted
             ? shot.experimental_fused_club_path_deg != null
-              ? 'camera fused (experimental)'
+              ? 'camera fused'
               : experimentalStatus(shot.experimental_fused_status)
             : clubPathIsExperimental
               ? experimentalStatus(shot.experimental_club_path_status)
@@ -189,7 +188,7 @@ function buildBallStrikeMetrics(shot: Shot, unitSystem: UnitSystem): LiveMetric[
           ? undefined
           : fusedDeliveryAttempted
             ? shot.experimental_fused_attack_angle_deg != null
-              ? 'camera fused (experimental)'
+              ? 'camera fused'
               : experimentalStatus(shot.experimental_fused_status)
             : attackIsExperimental
               ? experimentalStatus(shot.experimental_attack_angle_status)

--- a/ui/src/components/panel/panel.css
+++ b/ui/src/components/panel/panel.css
@@ -629,6 +629,21 @@
   max-width: 100%;
 }
 
+.live-panel__grid .metric-card__subtext {
+  display: block;
+  font-size: clamp(0.6875rem, 1.2vw, 0.75rem);
+  line-height: 1.15;
+  letter-spacing: 0.06em;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+.live-panel__grid .metric-card__confidence {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .live-panel__grid .metric-card__value-row {
   width: 100%;
   min-width: 0;

--- a/ui/tests/e2e/helpers.ts
+++ b/ui/tests/e2e/helpers.ts
@@ -179,4 +179,47 @@ export async function overflowingLiveMetricValues(page: Page): Promise<string[]>
   });
 }
 
+export async function overflowingLiveMetricMetadata(page: Page): Promise<string[]> {
+  await page.evaluate(() => document.fonts.ready);
+
+  return page.locator('.live-panel__grid .metric-card').evaluateAll((cards) => {
+    const slop = 2;
+    const overflows: string[] = [];
+
+    for (const card of cards) {
+      const cardRect = card.getBoundingClientRect();
+      const meta = card.querySelector('.metric-card__meta');
+      if (!(meta instanceof HTMLElement)) {
+        continue;
+      }
+
+      const overflowingText = [...meta.querySelectorAll('.metric-card__confidence-label')].find((label) => {
+        if (!(label instanceof HTMLElement)) {
+          return false;
+        }
+        const range = document.createRange();
+        range.selectNodeContents(label);
+        const textRects = [...range.getClientRects()];
+        return (
+          label.scrollWidth > label.clientWidth + slop ||
+          textRects.some(
+            (rect) =>
+              rect.left < cardRect.left - slop ||
+              rect.right > cardRect.right + slop ||
+              rect.top < cardRect.top - slop ||
+              rect.bottom > cardRect.bottom + slop
+          )
+        );
+      });
+
+      if (overflowingText) {
+        const labelText = card.querySelector('.metric-card__label')?.textContent?.trim() ?? 'unknown';
+        overflows.push(`${labelText} (${overflowingText.textContent?.trim() ?? ''})`);
+      }
+    }
+
+    return overflows;
+  });
+}
+
 export { expect };

--- a/ui/tests/e2e/live-metrics-layout.spec.ts
+++ b/ui/tests/e2e/live-metrics-layout.spec.ts
@@ -4,6 +4,7 @@ import {
   gotoApp,
   KIOSK_VIEWPORTS,
   liveMetricValueFontSizes,
+  overflowingLiveMetricMetadata,
   overflowingLiveMetricValues,
   simulateShot,
   WIDEST_LIVE_METRIC_VALUE,
@@ -41,6 +42,49 @@ for (const viewport of KIOSK_VIEWPORTS) {
       await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 
       expect(await overflowingLiveMetricValues(page)).toEqual([]);
+    });
+
+    test('keeps long metric subtitles readable inside each live tile', async ({ page }) => {
+      await withControlSocket(async (socket) => {
+        await simulateShot(socket);
+      });
+
+      await gotoApp(page);
+      await dismissPicker(page);
+
+      const subtitles = [
+        'spin-adjusted',
+        'camera assisted (experimental)',
+        'camera fused (experimental)',
+        'rejected: insufficient post trigger frames',
+        'player + implement',
+        '99 swings',
+        '99 readings',
+        '199.9 mph trigger',
+        'straight',
+        'candidate',
+      ];
+      await page.locator('.live-panel__grid .metric-card').evaluateAll((cards, text) => {
+        cards.forEach((card, index) => {
+          const meta = card.querySelector('.metric-card__meta');
+          if (!(meta instanceof HTMLElement)) return;
+
+          const subtitle = document.createElement('span');
+          subtitle.className = 'metric-card__subtext metric-card__confidence-label';
+          subtitle.textContent = text[index];
+          meta.replaceChildren(subtitle);
+
+          if (index === 2 || index === 3) {
+            const confidence = document.createElement('div');
+            confidence.className = 'metric-card__confidence metric-card__confidence--high';
+            confidence.innerHTML =
+              '<span class="metric-card__confidence-dots"><span class="dot filled"></span><span class="dot filled"></span><span class="dot filled"></span></span><span class="metric-card__confidence-label">experimental</span>';
+            meta.append(confidence);
+          }
+        });
+      }, subtitles);
+
+      expect(await overflowingLiveMetricMetadata(page)).toEqual([]);
     });
   });
 }


### PR DESCRIPTION
## What does this PR do?

- Lets every live-metric subtitle wrap within its tile using compact, kiosk-scaled typography.
- Keeps confidence metadata constrained to the tile instead of overflowing or becoming unreadable.
- Shortens camera-assisted/fused provenance while retaining the experimental label in the confidence row.
- Adds multi-viewport overflow coverage for long source, rejection, confidence, and training subtitles.

## Why was this required?

Long metric subtitles could overflow or become unreadable on the supported 800x400, 800x480, and 1024x600 kiosk layouts. The camera provenance strings were especially repetitive because experimental status appeared in both the subtitle and confidence metadata.

This work was split from the shot-latency PR so the visual change can be reviewed and released independently.

## Automated tests

- `liveMetrics.test.ts`: 16 tests passed.
- Chromium kiosk-layout regression: 6 tests passed across all three supported viewports.
- ESLint, TypeScript build, and Vite production build passed.

## Manual (human) testing

- Compared the revised layout against the reported physical-kiosk overflow photo.
- A physical Raspberry Pi kiosk was not available locally; supported viewport rendering is covered by the browser regression.

## Checklist

- [x] Single UI fix
- [x] Automated tests included
- [x] Manual testing described
- [x] UI builds and lint checks pass
- [x] No shot-pipeline changes included