### PR TITLE
ci: add anti-slop PR audit

### DIFF
--- a/.github/workflows/anti-slop.yml
+++ b/.github/workflows/anti-slop.yml
@@ -1,0 +1,124 @@
+name: Anti-slop Audit
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+# The audit only reads PR data. Change pull-requests to write when close-pr is
+# enabled or when label/comment failure actions are configured.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  anti-slop:
+    name: Audit PR quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit PR quality
+        id: anti-slop
+        uses: peakoss/anti-slop@57858eead489d08b255fab2af45a506c2ca6eab2 # v0.3.0
+        with:
+          # Authentication and failure threshold
+          github-token: ${{ github.token }}
+          max-failures: 4
+
+          # Branch checks
+          allowed-target-branches: ""
+          blocked-target-branches: ""
+          allowed-source-branches: ""
+          blocked-source-branches: |
+            main
+            master
+
+          # PR size checks
+          max-changed-files: 50
+          max-changed-lines: 2000
+
+          # PR quality checks
+          max-negative-reactions: 2
+          require-maintainer-can-modify: true
+
+          # PR title checks. The existing PR Checks workflow enforces titles.
+          require-conventional-title: false
+
+          # PR description checks
+          require-description: true
+          max-description-length: 6000
+          max-emoji-count: 2
+          max-code-references: 20
+          require-linked-issue: false
+          blocked-terms: ""
+          blocked-issue-numbers: ""
+
+          # PR template checks
+          require-pr-template: true
+          strict-pr-template-sections: "Checklist"
+          optional-pr-template-sections: ""
+          max-additional-pr-template-sections: 0
+
+          # Commit message checks
+          max-commit-message-length: 500
+          require-conventional-commits: false
+          require-commit-author-match: false
+          blocked-commit-authors: ""
+
+          # File checks
+          allowed-file-extensions: ""
+          allowed-paths: ""
+          blocked-paths: |
+            SECURITY.md
+            LICENSE
+            CODE_OF_CONDUCT.md
+          require-final-newline: true
+          max-added-comments: 25
+
+          # User checks
+          detect-spam-usernames: false
+          min-account-age: 30
+          max-daily-forks: 6
+          require-public-profile: false
+          min-profile-completeness: 2
+
+          # Contributor history checks
+          min-repo-merged-prs: 0
+          min-repo-merge-ratio: 0
+          min-global-merge-ratio: 30
+          global-merge-ratio-exclude-own: false
+
+          # Exemptions
+          exempt-draft-prs: true
+          exempt-bots: |
+            actions-user
+            autofix-ci[bot]
+            dependabot[bot]
+            renovate[bot]
+            github-actions[bot]
+          exempt-users: ""
+          exempt-author-association: ""
+          exempt-label: "anti-slop-exempt"
+          exempt-pr-label: ""
+          exempt-all-milestones: false
+          exempt-all-pr-milestones: false
+          exempt-milestones: ""
+          exempt-pr-milestones: ""
+
+          # Success actions
+          success-add-pr-labels: ""
+
+          # Failure actions. Audit mode reports findings without changing PRs.
+          failure-remove-pr-labels: ""
+          failure-remove-all-pr-labels: false
+          failure-add-pr-labels: ""
+          failure-pr-message: ""
+          close-pr: false
+          lock-pr: false
+
+      - name: Surface failed audit
+        if: steps.anti-slop.outputs.result == 'failed'
+        env:
+          FAILED_CHECKS: ${{ steps.anti-slop.outputs.failed-checks }}
+          TOTAL_CHECKS: ${{ steps.anti-slop.outputs.total-checks }}
+        run: |
+          echo "::warning title=Anti-slop audit::${FAILED_CHECKS}/${TOTAL_CHECKS} checks failed. Review the job summary for details."


### PR DESCRIPTION
## What does this PR do?

Adds a SHA-pinned, read-only anti-slop workflow that audits PRs when opened, reopened, updated, edited, or marked ready and emits a non-blocking warning when four configured checks fail.

## Why was this required?

This gives maintainers an observable audit period for calibrating PR-quality heuristics before enabling automatic closure.

## Automated tests

Validated the workflow YAML, matched all 57 configured inputs against the pinned v0.3.0 action contract, and ran `git diff --check` successfully.

## Manual (human) testing

Reviewed the complete workflow triggers, least-privilege permissions, thresholds, exemptions, and warning behavior, and verified that the `anti-slop-exempt` repository label exists.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [ ] **Automated tests included** — no executable application code changed; workflow contract validation was performed instead
- [x] **Manual testing described** — I documented what I verified by hand above
- [ ] Python tests pass (`uv run pytest tests/ -v`) — not run; Python code is unchanged
- [ ] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`) — not run; Python code is unchanged
- [ ] Ruff passes (`uv run ruff check src/openflight/`) — not run; Python code is unchanged
- [ ] UI builds (`cd ui && npm run build`) — not run; UI code is unchanged
- [ ] UI lint passes (`cd ui && npm run lint`) — not run; UI code is unchanged
- [x] Updated docs or CHANGELOG if needed — no documentation update is needed for this CI-only change
- [x] No unrelated changes mixed in