### PR TITLE
docs: add AI policy and anti-slop agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+This file provides mandatory guidance to coding agents working in this
+repository. It applies to the entire repository. More specific `AGENTS.md` files,
+such as `ui/AGENTS.md`, add rules for their directories and must also be read.
 
 ## Project Overview
 
@@ -12,6 +14,121 @@ OpenFlight is a DIY golf launch monitor using the OPS243-A Doppler radar and K-L
 - **Update `pyproject.toml` when adding dependencies.** If new Python packages are introduced, add them to the appropriate dependency list in `pyproject.toml`.
 - **Bug reports: write a failing test first.** When the user reports a bug, write a test that reproduces and confirms the bug before investigating or fixing it.
 - **Default startup is `scripts/start-kiosk.sh`.** Assume the project is started via this script unless told otherwise. It handles venv activation, UI build, and server launch.
+
+## Scope and Reviewability
+
+Agents must produce small, correct, and reviewable changes.
+
+- Keep every change scoped to one feature, fix, or documentation objective.
+- Make the smallest coherent diff that completely solves the requested problem.
+- Do not include unrelated cleanup, formatting, renames, dependency updates, or
+  opportunistic refactors.
+- Refactor only when it is necessary to implement or verify the requested change.
+  Put broader refactors in a separate proposal or pull request.
+- Do not change public APIs, data formats, hardware assumptions, architecture, or
+  module boundaries unless the task explicitly requires it.
+- If the task expands while investigating it, stop and surface the added scope
+  instead of silently broadening the change.
+- Never modify generated, vendored, binary, or model files unless the task
+  specifically targets them. Regenerate artifacts using their documented source
+  process rather than editing generated output by hand.
+
+## Implementation Guidelines
+
+- Inspect the surrounding code, tests, and local instructions before editing.
+- Search for existing helpers and patterns before adding new implementations.
+  Reuse or extend equivalent behavior instead of duplicating it.
+- Follow the existing structure and style. Prefer consistency with nearby code
+  over introducing a new pattern.
+- Prefer simple, explicit logic over clever or compact code.
+- Do not add wrappers, layers, configuration, fallbacks, or abstractions without
+  a concrete requirement. Shared abstractions must represent behavior that is
+  genuinely reused, not a hypothetical future need.
+- Keep functions and components focused, responsibilities separate, and coupling
+  visible. Avoid hidden side effects.
+- Handle realistic failure modes and boundary cases explicitly. Do not add
+  speculative edge-case machinery with no evidence that the case can occur.
+- Do not add a dependency when the standard library or an existing dependency
+  already provides the needed behavior.
+
+### Comments
+
+- Prefer clear code and names over explanatory comments.
+- Do not add comments that restate the next line or narrate the implementation.
+- Add comments only for non-obvious intent, hardware or protocol constraints,
+  compatibility requirements, or decisions that cannot be made clear in code.
+
+## Validation
+
+- New or changed behavior requires tests. Bug fixes require a regression test
+  that fails before the fix and passes after it.
+- Test observable behavior and failure paths. Do not weaken assertions, remove
+  coverage, or change tests merely to make an implementation pass.
+- Run targeted checks while iterating, then run all checks relevant to the
+  changed area before handing off. Use the commands documented below.
+- UI changes must follow `ui/AGENTS.md` and include the appropriate unit or E2E
+  coverage for affected kiosk sizes and input behavior.
+- Hardware-dependent work must state exactly what was tested on real hardware.
+  Mock or simulated validation must not be described as hardware validation.
+- Never claim a command passed unless it was actually run successfully. Report
+  skipped or unavailable checks and the reason.
+
+## Pull Requests and Anti-Slop Audit
+
+Pull requests must follow `.github/pull_request_template.md` and
+[CONTRIBUTING.md](CONTRIBUTING.md). The workflows under `.github/workflows/`
+enforce the following rules:
+
+- Work from a feature branch; `main` and `master` are blocked as PR source
+  branches.
+- Treat 50 changed files and 2,000 changed lines as hard ceilings, not targets.
+  Split a change well before either limit when it contains separable concerns.
+- Provide a concise, non-empty description of at most 6,000 characters, with no
+  more than two emojis and no more than 20 code references.
+- Preserve the PR template, complete every required section, and check every item
+  in `Checklist`. In particular, explain why the change is required, list the
+  automated tests, and describe manual human testing.
+- Use a conventional PR title in the form
+  `<type>(optional scope): <description>`. Allowed types are `feat`, `fix`,
+  `docs`, `refactor`, `test`, `chore`, `perf`, `build`, `ci`, `style`, and
+  `revert`.
+- Keep each commit message at or below 500 characters.
+- Ensure every changed text file ends with a newline.
+- Add no more than 25 comment lines across changed files. This is a ceiling;
+  include only comments that meet the comment rules above.
+- Do not change `SECURITY.md`, `LICENSE`, or `CODE_OF_CONDUCT.md` in an ordinary
+  PR. Such changes require explicit maintainer coordination.
+- Allow maintainers to modify the source branch. More than two combined
+  thumbs-down or confused reactions also triggers an audit finding.
+
+The audit additionally checks contributor spam signals: accounts must be at
+least 30 days old, must not fork more than six repositories in 24 hours, must
+have at least two populated profile signals, and must have at least a 30% global
+merge ratio. Draft PRs and configured bots are exempt. Maintainers can use the
+`anti-slop-exempt` label for legitimate exceptions.
+
+The audit reports an overall failure after four separate findings. It currently
+runs in audit mode and does not label, close, or lock a PR. Treat every check as
+a contribution requirement; do not try to spend the four-finding allowance or
+game the heuristics.
+
+## GitHub Communication
+
+- Write issue descriptions, PR descriptions, reviews, and comments for humans.
+  Lead with the relevant point and include only context needed to act on it.
+- Do not post generated walls of text, exhaustive code summaries, repeated
+  explanations, or play-by-play accounts of the work.
+- Keep claims specific and verifiable. Distinguish observed behavior from
+  assumptions and proposals.
+- Do not post comments, open issues, change labels, or submit reviews unless the
+  user explicitly asks for that external action.
+
+## AI-Assisted Contributions
+
+All agents and contributors must follow [AI-POLICY.md](AI-POLICY.md). In
+particular, contributors remain responsible for every submitted line, must be
+able to explain the change, must disclose substantive AI assistance, and must
+not present generated claims as human testing or investigation.
 
 # Codex Prompt for Plan Mode
 

--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -1,0 +1,89 @@
+# OpenFlight Generative AI Policy
+
+OpenFlight accepts thoughtful contributions made with or without generative AI.
+This policy applies to code, documentation, issues, pull requests, reviews, and
+other project communication created with large language models, code assistants,
+or similar tools ("AI tools").
+
+## Guiding Principle
+
+**AI assistance does not transfer responsibility.**
+
+The person submitting a contribution is accountable for its correctness,
+security, licensing, scope, and clarity. AI-generated work must meet the same
+standards as any other contribution. A contributor must understand the entire
+change, personally review it, and be able to explain and defend it during review.
+
+## Acceptable Use
+
+AI tools may be used to:
+
+- learn how an existing part of the project works;
+- brainstorm or compare focused implementation approaches;
+- complete small routines or repetitive boilerplate;
+- draft tests that the contributor reviews, strengthens, and runs;
+- refactor or reformat content within the requested scope; and
+- proofread or analyze a contributor's own work.
+
+These uses are acceptable only when the contributor:
+
+- remains involved from investigation through validation;
+- reviews every changed line and removes speculative or unnecessary output;
+- understands the relevant code paths and verifies assumptions against the
+  repository, authoritative documentation, or hardware behavior;
+- runs appropriate automated and manual tests and reports the results honestly;
+- keeps the contribution to one coherent feature or fix;
+- follows [AGENTS.md](AGENTS.md), [CONTRIBUTING.md](CONTRIBUTING.md), and the
+  project's licensing and security requirements; and
+- discloses substantive AI assistance as described below.
+
+## Unacceptable Use
+
+Do not use AI tools to:
+
+- submit code, documentation, or communication that has not been carefully
+  reviewed and edited by the contributor;
+- generate broad rewrites, speculative features, unrelated cleanup, or other
+  changes beyond the stated task;
+- rely on generated output as the sole basis for technical or architectural
+  decisions without independent investigation and validation;
+- claim that tests, hardware checks, benchmarks, or manual verification were
+  performed when they were not;
+- submit a change that the contributor cannot explain, contextualize, or
+  justify during review;
+- flood issues, pull requests, reviews, or discussions with generated reports,
+  repetitive comments, or responses that do not add personal judgment;
+- reproduce third-party work without compatible licensing and required
+  attribution; or
+- send secrets, credentials, private session data, or other non-public project
+  information to an AI service that is not approved to receive it.
+
+## Transparency
+
+Disclose substantive AI assistance in the pull request or other submission. A
+concise disclosure should identify the tool's role and the human review and
+validation performed. For example: "AI assistance drafted the test scaffolding;
+I revised every case and ran the full test file."
+
+Disclosure is not required for spelling corrections, search, or small
+autocomplete suggestions that did not materially shape the contribution.
+AI-assisted translation is permitted, but the contributor remains responsible
+for checking that it accurately represents their meaning.
+
+## Licensing
+
+By contributing, you represent that you have the right to submit the work under
+OpenFlight's AGPL-3.0-or-later license. AI tools may produce material derived
+from unidentified sources. If you cannot establish that generated material can
+be contributed under the project's license, do not submit it.
+
+## Review and Enforcement
+
+Maintainers may ask for a contribution to be reduced, rewritten, tested, or
+explained by the contributor. Unreviewed, undisclosed, misleading, or low-quality
+AI-assisted submissions may be closed or rejected. Repeated low-quality or
+automated submissions may result in contribution restrictions.
+
+This policy was informed by the
+[Cilium Generative AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md)
+and adapted for OpenFlight's development and review workflow.


### PR DESCRIPTION
## What does this PR do?

Adds an OpenFlight generative AI policy and expands the agent instructions with mandatory scope, implementation, validation, communication, and anti-slop audit rules. AI assistance drafted and validated the documentation, and the maintainer reviewed the final change.

## Why was this required?

Clear accountability and reviewability standards are needed to reduce low-quality AI-assisted submissions and keep pull requests focused.

## Automated tests

No tests were added because this is documentation-only; the existing suite passed with 1,593 tests and 10 skips, Pylint scored 9.73, Ruff passed, and the UI build and lint passed.

## Manual (human) testing

The maintainer reviewed the policy and agent guidance for scope and clarity; no runtime or hardware behavior changed.

## Checklist

- [x] **Single feature/fix** — this PR is scoped to one thing with a clear story above
- [ ] **Automated tests included** — new or updated tests cover this change
- [x] **Manual testing described** — I documented what I verified by hand above
- [x] Python tests pass (`uv run pytest tests/ -v`)
- [x] Pylint passes (`uv run pylint src/openflight/ --fail-under=9`)
- [x] Ruff passes (`uv run ruff check src/openflight/`)
- [x] UI builds (`cd ui && npm run build`)
- [x] UI lint passes (`cd ui && npm run lint`)
- [x] Updated docs or CHANGELOG if needed
- [x] No unrelated changes mixed in
